### PR TITLE
Reset the module search path on cabal launches

### DIFF
--- a/configs/04_for_cabal_launch.json
+++ b/configs/04_for_cabal_launch.json
@@ -17,7 +17,7 @@
             "mainArgs": "",
             "ghciPrompt": "H>>= ",
             "ghciInitialPrompt": "Prelude>",
-            "ghciCmd": "cabal exec -- ghci-dap --interactive -i${workspaceFolder}",
+            "ghciCmd": "cabal exec -- ghci-dap --interactive -i -i${workspaceFolder}",
             "ghciEnv": {},
             "logFile": "${workspaceFolder}/.vscode/phoityne.log",
             "logLevel": "WARNING",


### PR DESCRIPTION
Without an `-i` option with no directory, break points cannot be set
outside of `Main.hs` nor can one step into a function defined outside of
`Main.hs`.

Fixes https://github.com/phoityne/hdx4vsc/issues/10.