### PR TITLE
Add example for multicomponent cabal projects

### DIFF
--- a/configs/05_cabal_multiproject.json
+++ b/configs/05_cabal_multiproject.json
@@ -1,0 +1,52 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "ghc",
+            "request": "launch",
+            "name": "componentA",
+            "internalConsoleOptions": "openOnSessionStart",
+            "workspace": "${workspaceFolder}",
+            "startup": "${workspaceFolder}/test/componentA/Main.hs",
+            "startupFunc": "",
+            "startupArgs": "",
+            "stopOnEntry": false,
+            "mainArgs": "",
+            "ghciPrompt": "H>>= ",
+            "ghciInitialPrompt": "> ",
+            "ghciCmd": "cabal repl --with-compiler ghci-dap --repl-no-load --builddir=${workspaceFolder}/.vscode/dist-cabal-repl componentA",
+            "ghciEnv": {},
+            "logFile": "${workspaceFolder}/.vscode/initialise-test.log",
+            "logLevel": "INFO",
+            "forceInspect": false
+        },
+        {
+            "type": "ghc",
+            "request": "launch",
+            "name": "componentB",
+            "internalConsoleOptions": "openOnSessionStart",
+            "workspace": "${workspaceFolder}",
+            "startup": "${workspaceFolder}/test/componentB/Main.hs",
+            "startupFunc": "",
+            "startupArgs": "",
+            "stopOnEntry": false,
+            "mainArgs": "",
+            "ghciPrompt": "H>>= ",
+            "ghciInitialPrompt": "> ",
+            "ghciCmd": "cabal repl --with-compiler ghci-dap --repl-no-load --builddir=${workspaceFolder}/.vscode/dist-cabal-repl componentB",
+            "ghciEnv": {},
+            "logFile": "${workspaceFolder}/.vscode/initialise-test.log",
+            "logLevel": "INFO",
+            "forceInspect": false
+        }
+    ],
+    "compounds": [
+        {
+            "name": "cabal",
+            "configurations": ["componentA", "componentB"]
+        }
+    ]
+}


### PR DESCRIPTION
I struggled through this configuration recently and thought it might be useful to include in the example configurations.

If there is any interest in an update to the documentation in general I'd like to add some Diataxis organised documentation on using this plugin with cabal.  Let me know if that's a reasonable extension and I'll submit more pull requests.  Otherwise, this simple addition will suffice.